### PR TITLE
Rose pine fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Themes for [eza](https://github.com/eza-community/eza).
 
 - [Rosé Pine](themes/rose-pine.yml): All natural pine, faux fur and a bit of soho vibes for the classy minimalist. Created with the main [Rosé Pine](https://github.com/rose-pine/rose-pine-theme) palette.
 
-<img src="imgs/rose-pine.png" alt="tokyonight theme" width="500" />
+<img src="imgs/rose-pine.png" alt="rose pine theme" width="500" />
 
 ## Installation
 

--- a/themes/rose-pine.yml
+++ b/themes/rose-pine.yml
@@ -110,7 +110,7 @@ file_type:
 punctuation: {foreground: "#524f67"}
 date: {foreground: "#31748f"}
 inode: {foreground: "#908caa"}
-blocks: {foreground: "#9399B2"}
+blocks: {foreground: "#6e6a86"}
 header: {foreground: "#908caa"}
 octal: {foreground: "#9ccfd8"}
 flags: {foreground: "#c4a7e7"}


### PR DESCRIPTION
Fixed an incorrect color code used for blocks and fixed the alt text shown for the rose-pine.png