### PR TITLE
Feature: Lint YAML files and add linter workflow

### DIFF
--- a/.github/workflows/convco.yml
+++ b/.github/workflows/convco.yml
@@ -1,6 +1,7 @@
+---
 name: commit
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/nomerge.yml
+++ b/.github/workflows/nomerge.yml
@@ -1,6 +1,7 @@
+---
 name: commit
 
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: [main]
 

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,16 @@
+---
+name: 'Lint YAML'
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+jobs:
+  yamllint:
+    name: 'Lint YAML'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+      - name: 'Yamllint'
+        uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_strict: true
+          yamllint_comment: false

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,11 @@
+---
+
+extends: default
+
+rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1

--- a/themes/black.yml
+++ b/themes/black.yml
@@ -1,3 +1,4 @@
+---
 colourful: false
 
 filekinds:
@@ -102,9 +103,9 @@ broken_symlink: {foreground: "#000"}
 broken_path_overlay: {foreground: "#000"}
 
 filenames:
-  # Custom filename-based overrides
-  # Cargo.toml: {icon: {glyph: 🦀}}
+# Custom filename-based overrides
+# Cargo.toml: {icon: {glyph: 🦀}}
 
 extensions:
-  # Custom extension-based overrides
-  # rs: {filename: {foreground: Red}, icon: {glyph: 🦀}}
+# Custom extension-based overrides
+# rs: {filename: {foreground: Red}, icon: {glyph: 🦀}}

--- a/themes/catppuccin.yml
+++ b/themes/catppuccin.yml
@@ -1,3 +1,4 @@
+---
 colourful: true
 
 filekinds:

--- a/themes/default.yml
+++ b/themes/default.yml
@@ -1,3 +1,4 @@
+---
 colourful: true
 
 filekinds:
@@ -102,9 +103,9 @@ broken_symlink: {foreground: Red}
 broken_path_overlay: {foreground: Default, is_underline: true}
 
 filenames:
-  # Custom filename-based overrides
-  # Cargo.toml: {icon: {glyph: 🦀}}
+# Custom filename-based overrides
+# Cargo.toml: {icon: {glyph: 🦀}}
 
 extensions:
-  # Custom extension-based overrides
-  # rs: {filename: {foreground: Red}, icon: {glyph: 🦀}}
+# Custom extension-based overrides
+# rs: {filename: {foreground: Red}, icon: {glyph: 🦀}}

--- a/themes/dracula.yml
+++ b/themes/dracula.yml
@@ -1,3 +1,4 @@
+---
 colourful: true
 # yellow #F1FA8C
 # red    #FF5555

--- a/themes/frosty.yml
+++ b/themes/frosty.yml
@@ -1,3 +1,4 @@
+---
 # colors:
 #  - light icy blue: #E0F7FA
 #  - snow white: #FFFFFF
@@ -111,9 +112,9 @@ broken_symlink: {foreground: "#FF8A80"}
 broken_path_overlay: {foreground: "#607D8B"}
 
 filenames:
-  # Custom filename-based overrides
-  # Cargo.toml: {icon: {glyph: 🦀}}
+# Custom filename-based overrides
+# Cargo.toml: {icon: {glyph: 🦀}}
 
 extensions:
-  # Custom extension-based overrides
-  # rs: {filename: {foreground: Red}, icon: {glyph: 🦀}}
+# Custom extension-based overrides
+# rs: {filename: {foreground: Red}, icon: {glyph: 🦀}}

--- a/themes/gruvbox-dark.yml
+++ b/themes/gruvbox-dark.yml
@@ -1,3 +1,4 @@
+---
 colourful: true
 
 filekinds:

--- a/themes/gruvbox-light.yml
+++ b/themes/gruvbox-light.yml
@@ -1,3 +1,4 @@
+---
 colourful: true
 
 filekinds:

--- a/themes/one_dark.yml
+++ b/themes/one_dark.yml
@@ -1,3 +1,4 @@
+---
 colourful: true
 
 filekinds:
@@ -100,4 +101,3 @@ symlink_path: {foreground: "#56B6C2"}
 control_char: {foreground: "#61AFEF"}
 broken_symlink: {foreground: "#E06C75"}
 broken_path_overlay: {foreground: "#5C6370"}
-

--- a/themes/rose-pine-dawn.yml
+++ b/themes/rose-pine-dawn.yml
@@ -1,3 +1,4 @@
+---
 colourful: true
 
 # Colors are in format of:

--- a/themes/rose-pine-moon.yml
+++ b/themes/rose-pine-moon.yml
@@ -1,3 +1,4 @@
+---
 colourful: true
 
 # Colors are in format of:

--- a/themes/rose-pine.yml
+++ b/themes/rose-pine.yml
@@ -1,3 +1,4 @@
+---
 colourful: true
 
 # Colors are in format of:

--- a/themes/tokyonight.yml
+++ b/themes/tokyonight.yml
@@ -1,3 +1,4 @@
+---
 colourful: true
 
 filekinds:

--- a/themes/white.yml
+++ b/themes/white.yml
@@ -1,3 +1,4 @@
+---
 colourful: false
 
 filekinds:
@@ -102,9 +103,9 @@ broken_symlink: {foreground: "#fff"}
 broken_path_overlay: {foreground: "#fff"}
 
 filenames:
-  # Custom filename-based overrides
-  # Cargo.toml: {icon: {glyph: 🦀}}
+# Custom filename-based overrides
+# Cargo.toml: {icon: {glyph: 🦀}}
 
 extensions:
-  # Custom extension-based overrides
-  # rs: {filename: {foreground: Red}, icon: {glyph: 🦀}}
+# Custom extension-based overrides
+# rs: {filename: {foreground: Red}, icon: {glyph: 🦀}}


### PR DESCRIPTION
I went to add some of these themes to my repo and noticed that they don't pass my linting rules. I figured I'd contribute back with some quick linting fixes and a GitHub workflow to test.